### PR TITLE
move babel-jest to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "autoprefixer-loader": "^3.2.0",
         "babel-core": "^6.24.1",
         "babel-eslint": "^7.2.3",
+        "babel-jest": "^21.2.0",
         "babel-loader": "^7.0.0",
         "babel-plugin-react-transform": "^2.0.2",
         "babel-plugin-transform-class-properties": "^6.24.1",
@@ -100,8 +101,5 @@
         "setupFiles": [
             "<rootDir>/setupFile.js"
         ]
-    },
-    "dependencies": {
-        "babel-jest": "^21.2.0"
     }
 }


### PR DESCRIPTION
Hi! It seems like babel-jest ought to go in devDependencies. I just made the change by editing it on GitHub, hopefully my assumptions are correct. Thanks!