### PR TITLE
fix: migrate `componentWillReceiveProps` to `componentDidUpdate`

### DIFF
--- a/src/modules/Parallax.js
+++ b/src/modules/Parallax.js
@@ -75,7 +75,16 @@ class Parallax extends Component {
         }
     }
 
-    componentWillReceiveProps(nextProps) {
+    shouldComponentUpdate(nextProps, nextState) {
+        const { bgImage } = this.props;
+        const { bgImage: stateBgImage } = this.state;
+        if (nextProps.bgImage !== bgImage && nextState.bgImage === stateBgImage) {
+            return false;
+        }
+        return true;
+    }
+
+    componentDidUpdate(nextProps) {
         const { parent, bgImage, bgImageSrcSet, bgImageSizes } = nextProps;
         const { bgImage: stateBgImage } = this.state;
         this.splitChildren = getSplitChildren(nextProps);
@@ -89,15 +98,6 @@ class Parallax extends Component {
         if (stateBgImage !== bgImage) {
             this.loadImage(bgImage, bgImageSrcSet, bgImageSizes);
         }
-    }
-
-    shouldComponentUpdate(nextProps, nextState) {
-        const { bgImage } = this.props;
-        const { bgImage: stateBgImage } = this.state;
-        if (nextProps.bgImage !== bgImage && nextState.bgImage === stateBgImage) {
-            return false;
-        }
-        return true;
     }
 
     /**

--- a/src/modules/Parallax.js
+++ b/src/modules/Parallax.js
@@ -84,10 +84,10 @@ class Parallax extends Component {
         return true;
     }
 
-    componentDidUpdate(nextProps) {
-        const { parent, bgImage, bgImageSrcSet, bgImageSizes } = nextProps;
+    componentDidUpdate() {
+        const { parent, bgImage, bgImageSrcSet, bgImageSizes } = this.props;
         const { bgImage: stateBgImage } = this.state;
-        this.splitChildren = getSplitChildren(nextProps);
+        this.splitChildren = getSplitChildren(this.props);
         if (parent && this.parent !== parent) {
             this.parent = parent;
             this.removeListeners();


### PR DESCRIPTION
As of [React 16.9.0](https://github.com/facebook/react/releases/tag/v16.9.0) the `componentWillReceiveProps` method has been deprecated and will be removed in v17. In looking at the code, it appears that a direct swap to the `componentDidUpdate` method will suffice and continued to work on the local dev server examples.

**NOTE:** Upon forking the repo and installing the dependencies I did see that the `utils › isScrolledIntoView` test was failing on master. I checked it against Node v8 and v10. I'm not sure if this was a known issue or concern.