### PR TITLE
Add children prop to meet React 18 strict mode types

### DIFF
--- a/@types/index.ts
+++ b/@types/index.ts
@@ -43,6 +43,7 @@ type ParallaxState = {
 
 export type BackgroundProps = {
     className?: string;
+    children?: React.ReactNode
 };
 
 export type ParallaxChildrenProps = {


### PR DESCRIPTION
Adds the `children?: React.ReactNode` prop type to Background since it is required in React 18's strict mode to be able to pass a children to a component

![Screen Shot 2022-06-03 at 11 05 20](https://user-images.githubusercontent.com/4448627/171903281-f399fd1f-03ec-4888-a6f7-01c2c3330e9a.png)
.

To reproduce the issue you have to be on React 18 on strict mode.